### PR TITLE
Fix for console and ability to save on launch

### DIFF
--- a/love-launcher/CHANGELOG
+++ b/love-launcher/CHANGELOG
@@ -4,7 +4,7 @@
 1.0.1
 - Several small fixes
 
-1.0.2 
+1.0.2
 - Added a ReadMe
 
 1.0.3
@@ -12,3 +12,7 @@
 
 1.0.4
 - Added support overwriting the game on each launch. The switch for that is stored in the use settings.
+
+1.0.5
+- Added support for saving all files on launch
+- Fixed console support

--- a/love-launcher/package.json
+++ b/love-launcher/package.json
@@ -2,7 +2,7 @@
     "name": "love-launcher",
     "displayName": "Löve Launcher",
     "description": "Launches your project in Löve via a shortcut",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "icon": "logo.svg",
     "galleryBanner": {
         "color": "#6CBEE4",
@@ -63,6 +63,11 @@
                     "type": "boolean",
                     "description": "Should the launcher overwrite the first process when launching another one?",
                     "default": true
+                },
+                "lövelauncher.saveAllonLaunch": {
+                    "type": "boolean",
+                    "description": "Should VS Code save all opened files on Löve launch?",
+                    "default": false
                 }
             }
         }

--- a/love-launcher/src/extension.ts
+++ b/love-launcher/src/extension.ts
@@ -4,17 +4,19 @@ var exec = require('child_process').execFile;
 var currentInstances = [];
 
 export function activate(context: vscode.ExtensionContext) {
-
-    
     var maxInstances = vscode.workspace.getConfiguration('lövelauncher').get('maxInstances');
     var overWrite = vscode.workspace.getConfiguration('lövelauncher').get('overWrite');
-  
 
     let disposable = vscode.commands.registerCommand('lövelauncher.launch', () => {
 
         if(currentInstances.length < maxInstances || overWrite){
             var path : string = vscode.workspace.getConfiguration('lövelauncher').get('path').toString();
             var useConsoleSubsystem = vscode.workspace.getConfiguration('lövelauncher').get('useConsoleSubsystem');
+            var saveAllonLaunch = vscode.workspace.getConfiguration('lövelauncher').get('saveAllonLaunch');
+
+            if (saveAllonLaunch){
+                vscode.workspace.saveAll();
+            }
 
             if (overWrite){
                 currentInstances.forEach(function(instance){
@@ -23,27 +25,26 @@ export function activate(context: vscode.ExtensionContext) {
                     }
                 });
             }
-            
+
             if(!useConsoleSubsystem){
-                
-                var process = (exec(path, [vscode.workspace.rootPath], function(err, data) {  
-              
-                }));  
+
+                var process = exec(path, [vscode.workspace.rootPath], function(err, data) {
+
+                });
                 process.on('exit', on_exit.bind(null,process));
                 currentInstances[process.pid] = process;
             }else{
-                
-                path = path.substr(0,path.lastIndexOf(".")) + "c.exe";
-                var process = exec(path, [vscode.workspace.rootPath], function(err, data) {  
-                    //currentInstances--;                
-                });  
+
+                var process = exec(path, [vscode.workspace.rootPath, "--console"], function (err, data) {
+
+                });
                 process.on('exit', on_exit.bind(null,process));
                 currentInstances[process.pid] = process;
             }
         }else{
             vscode.window.showErrorMessage("You have reached your max concurrent Löve instances. You can change this setting in your config.");
         }
-        
+
     });
 
     context.subscriptions.push(disposable);

--- a/love-launcher/src/extension.ts
+++ b/love-launcher/src/extension.ts
@@ -8,7 +8,6 @@ export function activate(context: vscode.ExtensionContext) {
     var overWrite = vscode.workspace.getConfiguration('lövelauncher').get('overWrite');
 
     let disposable = vscode.commands.registerCommand('lövelauncher.launch', () => {
-
         if(currentInstances.length < maxInstances || overWrite){
             var path : string = vscode.workspace.getConfiguration('lövelauncher').get('path').toString();
             var useConsoleSubsystem = vscode.workspace.getConfiguration('lövelauncher').get('useConsoleSubsystem');
@@ -27,14 +26,12 @@ export function activate(context: vscode.ExtensionContext) {
             }
 
             if(!useConsoleSubsystem){
-
                 var process = exec(path, [vscode.workspace.rootPath], function(err, data) {
 
                 });
                 process.on('exit', on_exit.bind(null,process));
                 currentInstances[process.pid] = process;
             }else{
-
                 var process = exec(path, [vscode.workspace.rootPath, "--console"], function (err, data) {
 
                 });


### PR DESCRIPTION
Love sends output to a console when using lovec.exe only if you actually start it from a console. Adding --console spawns new console on launch.
Saving all files on launch is usefull sometimes (or all the time if you're me) so why not.