### PR TITLE
Use the workspace path instead of the file.

### DIFF
--- a/love-launcher/src/extension.ts
+++ b/love-launcher/src/extension.ts
@@ -59,13 +59,18 @@ export function activate(context: vscode.ExtensionContext) {
 				}
 
 				var process = null;
+				const Folders = vscode.workspace.workspaceFolders;
+				let loveProjectPath = actDocPath;
+				if (Folders){
+					loveProjectPath = Folders[0].uri.fsPath
+				}
 
 				if (os.platform() === 'win32'){
 					if (!useConsoleSubsystem) {
-						process = cp.spawn(path, [actDocPath]);
+						process = cp.spawn(path, [loveProjectPath]);
 						currentInstances[Number(process.pid)] = process;
 					} else {
-						process = cp.spawn(path, [actDocPath, "--console"]);
+						process = cp.spawn(path, [loveProjectPath, "--console"]);
 						currentInstances[Number(process.pid)] = process;
 					}
 				}else{


### PR DESCRIPTION
During the development process, pressing Alt+L will run with the current file folder as the main. lua directory.  
Therefore, when running in a non main.lua directory, Love2D will report an error of *love "boot. lua" 321 no code to run.*    
  
Therefore, I have made some modifications.  
**If the workspace is currently open, it will run with the current workspace as the directory.**